### PR TITLE
[FIX BUG] fix pie chart width from % to vw for animation activation on Skills page

### DIFF
--- a/src/style/components/ContentMain/Skills.css
+++ b/src/style/components/ContentMain/Skills.css
@@ -22,8 +22,7 @@
 .skills-piechart > .piechart {
     position: relative;
     height: 30vh!important;
-    /* width: 30vh!important; */
-    width: 90%;
+    width: 13vw!important;
     max-width: 30vw!important;
     font-size: var(--fontSize02)!important;
 }


### PR DESCRIPTION
If define the width by %, pie chart animation won't work.